### PR TITLE
Disable Alpine build in TeamCity temporarily

### DIFF
--- a/.teamcity/src/main/kotlin/Platform.kt
+++ b/.teamcity/src/main/kotlin/Platform.kt
@@ -17,7 +17,8 @@
 import jetbrains.buildServer.configs.kotlin.Requirements
 
 enum class Agent(val os: Os, val architecture: Architecture, val container: String? = null, val optional: Boolean = false) {
-    AlpineLinuxAmd64(os = Os.Ubuntu22, architecture = Architecture.Amd64, container = "openjdk:17-alpine", optional = true),
+    // TODO Re-enable Alpine build
+    // AlpineLinuxAmd64(os = Os.Ubuntu22, architecture = Architecture.Amd64, container = "openjdk:17-alpine", optional = true),
     UbuntuAmd64(os = Os.Ubuntu16, architecture = Architecture.Amd64),
     UbuntuAarch64(os = Os.Ubuntu24, architecture = Architecture.Aarch64),
     CentOsAmd64(os = Os.CentOs, architecture = Architecture.Amd64),


### PR DESCRIPTION
We need to make sure Git is available, or that the version number is not read while running external tests.