### PR TITLE
TeamCity: switch alpine testing away from the deprecated openjdk container to eclipse-temurin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: '0.14.0-dev.1320+492cc2ef8'
+          version: '0.14.0-dev.1911+3bf89f55c'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.teamcity/src/main/kotlin/Platform.kt
+++ b/.teamcity/src/main/kotlin/Platform.kt
@@ -17,7 +17,7 @@
 import jetbrains.buildServer.configs.kotlin.Requirements
 
 enum class Agent(val os: Os, val architecture: Architecture, val container: String? = null, val optional: Boolean = false) {
-    AlpineLinuxAmd64(os = Os.Ubuntu22, architecture = Architecture.Amd64, container = "openjdk:17-alpine"),
+    AlpineLinuxAmd64(os = Os.Ubuntu22, architecture = Architecture.Amd64, container = "eclipse-temurin:17-alpine"),
     UbuntuAmd64(os = Os.Ubuntu16, architecture = Architecture.Amd64),
     UbuntuAarch64(os = Os.Ubuntu24, architecture = Architecture.Aarch64),
     CentOsAmd64(os = Os.CentOs, architecture = Architecture.Amd64),

--- a/build-logic/src/main/kotlin/gradlebuild/ZigInstall.kt
+++ b/build-logic/src/main/kotlin/gradlebuild/ZigInstall.kt
@@ -70,7 +70,11 @@ abstract class ZigInstall @Inject constructor(@Inject val exec: ExecOperations) 
         cacheRoot.mkdirs()
         val zigArchive = cacheRoot.resolve("${zigName(zigVersion.get())}.tar.xz")
         // TODO Figure out OS and architecture
-        downloadFile("https://ziglang.org/builds/${zigName(zigVersion.get())}.tar.xz", zigArchive)
+        if (zigVersion.get().contains('-')) {
+          downloadFile("https://ziglang.org/builds/${zigName(zigVersion.get())}.tar.xz", zigArchive)
+        } else {
+          downloadFile("https://ziglang.org/download/${zigVersion.get()}/${zigName(zigVersion.get())}.tar.xz", zigArchive)
+        }
         unpackTarXz(zigArchive, installDir)
         val executable = installDir.zigExecutablePath(zigVersion.get())
         executable.setExecutable(true, false)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ sourceSets {
 }
 
 zig {
-    zigVersion = "0.14.0-dev.1320+492cc2ef8"
+    zigVersion = "0.14.0-dev.1911+3bf89f55c"
     outputDir = layout.buildDirectory.dir("zig")
     targets {
         create("x86_64-linux-gnu")


### PR DESCRIPTION
https://hub.docker.com/_/openjdk states:
> This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP.
> ...
> The only tags which will continue to receive updates beyond July 2022 will be Early Access builds (which are sourced from [jdk.java.net⁠](https://jdk.java.net/))

More information about the deprecation is shared in:
* https://github.com/docker-library/openjdk/issues/505