### PR TITLE
Remove custom debug logging

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,7 +26,6 @@ pub fn build(b: *std.Build) void {
         "-Wextra",
         "-Wformat=2",
         "-Werror",
-        "-Wno-deprecated-declarations",
         "-Wno-format-nonliteral",
         "-Wno-unguarded-availability-new",
     };

--- a/src/main/cpp/generic_fsnotifier.cpp
+++ b/src/main/cpp/generic_fsnotifier.cpp
@@ -174,15 +174,6 @@ Java_org_gradle_fileevents_internal_AbstractNativeFileEventFunctions_00024Native
     }
 }
 
-JNIEXPORT void JNICALL
-Java_org_gradle_fileevents_internal_AbstractNativeFileEventFunctions_invalidateLogLevelCache0(JNIEnv* env, jobject) {
-    try {
-        logging->invalidateLogLevelCache();
-    } catch (const exception& e) {
-        rethrowAsJavaException(env, e);
-    }
-}
-
 NativePlatformJniConstants::NativePlatformJniConstants(JavaVM* jvm)
     : JniSupport(jvm)
     , nativeExceptionClass(getThreadEnv(), "net/rubygrapefruit/platform/NativeException") {

--- a/src/main/cpp/logging.cpp
+++ b/src/main/cpp/logging.cpp
@@ -5,24 +5,7 @@
 Logging::Logging(JavaVM* jvm)
     : JniSupport(jvm)
     , clsLogger(getThreadEnv(), "org/gradle/fileevents/internal/NativeLogger")
-    , logMethod(getThreadEnv()->GetStaticMethodID(clsLogger.get(), "log", "(ILjava/lang/String;)V"))
-    , getLevelMethod(getThreadEnv()->GetStaticMethodID(clsLogger.get(), "getLogLevel", "()I")) {
-}
-
-void Logging::invalidateLogLevelCache() {
-    lastLevelCheck = chrono::steady_clock::time_point();
-}
-
-bool Logging::enabled(LogLevel level) {
-    auto current = chrono::steady_clock::now();
-    auto elapsed = chrono::duration_cast<chrono::milliseconds>(current - lastLevelCheck).count();
-    if (elapsed > LOG_LEVEL_CHECK_INTERVAL_IN_MS) {
-        JNIEnv* env = getThreadEnv();
-        minimumLogLevel = env->CallStaticIntMethod(clsLogger.get(), getLevelMethod);
-        rethrowJavaException(env);
-        lastLevelCheck = current;
-    }
-    return minimumLogLevel <= static_cast<int>(level);
+    , logMethod(getThreadEnv()->GetStaticMethodID(clsLogger.get(), "log", "(ILjava/lang/String;)V")) {
 }
 
 void Logging::send(LogLevel level, const char* fmt, ...) {

--- a/src/main/cpp/win_fsnotifier.cpp
+++ b/src/main/cpp/win_fsnotifier.cpp
@@ -3,14 +3,26 @@
 #include "win_fsnotifier.h"
 #include "command.h"
 
-#include <codecvt>
 #include <locale>
 
 using namespace std;
 
-string wideToUtf8String(const wstring& string) {
-    wstring_convert<deletable_facet<codecvt<wchar_t, char, mbstate_t>>, wchar_t> conv;
-    return conv.to_bytes(string);
+string wideToUtf8String(const wstring& wstr) {
+    if (wstr.empty()) return std::string();
+
+    int utf8Size = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), static_cast<int>(wstr.size()), nullptr, 0, nullptr, nullptr);
+    if (utf8Size == 0) {
+        return std::string("INVALID_UTF8");
+    }
+
+    std::string utf8Str(utf8Size, '\0');
+
+    int result = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), static_cast<int>(wstr.size()), &utf8Str[0], utf8Size, nullptr, nullptr);
+    if (result == 0) {
+        return std::string("INVALID_UTF8");
+    }
+
+    return utf8Str;
 }
 
 #define wideToUtf16String(string) (u16string((string).begin(), (string).end()))

--- a/src/main/headers/logging.h
+++ b/src/main/headers/logging.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <chrono>
 #include <jni.h>
 
 #include "jni_support.h"
@@ -19,18 +18,13 @@ class Logging : public JniSupport {
 public:
     Logging(JavaVM* jvm);
 
-    void invalidateLogLevelCache();
-    bool enabled(LogLevel level);
     void send(LogLevel level, const char* fmt, ...);
 
 private:
-    int minimumLogLevel;
     const JClass clsLogger;
     const jmethodID logMethod;
-    const jmethodID getLevelMethod;
-    chrono::time_point<chrono::steady_clock> lastLevelCheck;
 };
 
 extern Logging* logging;
 
-#define logToJava(level, message, ...) (logging->enabled(level) ? logging->send(level, message, __VA_ARGS__) : ((void) NULL))
+#define logToJava(level, message, ...) logging->send(level, message, __VA_ARGS__)

--- a/src/main/java/org/gradle/fileevents/internal/AbstractNativeFileEventFunctions.java
+++ b/src/main/java/org/gradle/fileevents/internal/AbstractNativeFileEventFunctions.java
@@ -12,16 +12,6 @@ public abstract class AbstractNativeFileEventFunctions<W extends FileWatcher> ex
 
     private static native String getVersion0();
 
-    /**
-     * Forces the native backend to drop the cached SLF4J log level and thus
-     * re-query it the next time it tries to log something to the Java side.
-     */
-    public void invalidateLogLevelCache() {
-        invalidateLogLevelCache0();
-    }
-
-    private native void invalidateLogLevelCache0();
-
     protected static abstract class NativeFileWatcher extends AbstractFileWatcher {
         protected final Object server;
 

--- a/src/main/java/org/gradle/fileevents/internal/NativeLogger.java
+++ b/src/main/java/org/gradle/fileevents/internal/NativeLogger.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 // Used from native
 @SuppressWarnings("unused")
@@ -14,27 +13,20 @@ public class NativeLogger {
     static final Logger LOGGER = LoggerFactory.getLogger(NativeLogger.class);
 
     enum LogLevel {
-        TRACE(LOGGER::trace, LOGGER::isTraceEnabled),
-        DEBUG(LOGGER::debug, LOGGER::isDebugEnabled),
-        INFO(LOGGER::info, LOGGER::isInfoEnabled),
-        WARN(LOGGER::warn, LOGGER::isWarnEnabled),
-        ERROR(LOGGER::error, LOGGER::isErrorEnabled),
-        OFF(__ -> {}, () -> true);
+        TRACE(LOGGER::trace),
+        DEBUG(LOGGER::debug),
+        INFO(LOGGER::info),
+        WARN(LOGGER::warn),
+        ERROR(LOGGER::error);
 
         private final Consumer<String> logger;
-        private final Supplier<Boolean> isEnabled;
 
-        LogLevel(Consumer<String> logger, Supplier<Boolean> isEnabled) {
+        LogLevel(Consumer<String> logger) {
             this.logger = logger;
-            this.isEnabled = isEnabled;
         }
 
         Consumer<String> getLogger() {
             return logger;
-        }
-
-        boolean isEnabled() {
-            return isEnabled.get();
         }
     }
 
@@ -42,13 +34,5 @@ public class NativeLogger {
 
     public static void log(int level, String message) {
         logLevels.get(level).getLogger().accept(message);
-    }
-
-    public static int getLogLevel() {
-        return Arrays.stream(LogLevel.values())
-            .filter(LogLevel::isEnabled)
-            .findFirst()
-            .map(LogLevel::ordinal)
-            .orElseThrow(() -> new AssertionError("Effective log level is not set"));
     }
 }

--- a/src/test/groovy/org/gradle/fileevents/internal/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/org/gradle/fileevents/internal/BasicFileEventFunctionsTest.groovy
@@ -690,9 +690,10 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         "URL-quoted"     | "test%<directory>#2.txt" | !Platform.current().windows
     }
 
-    def "can set log level by #action"() {
+    @SuppressWarnings('UnnecessaryQualifiedReference')
+    def "can set log level"() {
         given:
-        def nativeLogger = LoggerFactory.getLogger(NativeLogger)
+        def nativeLogger = LoggerFactory.getLogger(NativeLogger) as ch.qos.logback.classic.Logger
         def originalLevel = nativeLogger.level
         def fileChanged = new File(rootDir, "changed.txt")
         fileChanged.createNewFile()
@@ -700,7 +701,6 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         when:
         logging.clear()
         nativeLogger.level = ch.qos.logback.classic.Level.TRACE
-        ensureLogLevelInvalidated(service)
         startWatcher(rootDir)
         fileChanged << "changed"
         waitForChangeEventLatency()
@@ -712,7 +712,6 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         shutdownWatcher()
         logging.clear()
         nativeLogger.level = ch.qos.logback.classic.Level.WARN
-        ensureLogLevelInvalidated(service)
         startWatcher()
         fileChanged << "changed again"
         waitForChangeEventLatency()
@@ -722,11 +721,6 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
 
         cleanup:
         nativeLogger.level = originalLevel
-
-        where:
-        action                                    | ensureLogLevelInvalidated
-        "invalidating the log level cache"        | { AbstractFileEventFunctions service -> service.invalidateLogLevelCache() }
-        "waiting for log level cache to time out" | { Thread.sleep(1500) }
     }
 
     def "handles queue not able to take any events"() {


### PR DESCRIPTION
This feature was needed when we used JUL for logging, but is not necessary anymore.

Looks like we also caught a problem with Unicode conversion used in logging on Windows. This should now be fixed as part of the PR, too.