### PR TITLE
Test startup watcher timeout via synthetic test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ sourceSets {
 }
 
 zig {
-    zigVersion = "0.14.0-dev.1911+3bf89f55c"
+    zigVersion = "0.14.0-dev.2254+73f2671c7"
     outputDir = layout.buildDirectory.dir("zig")
     targets {
         create("x86_64-linux-gnu")

--- a/src/test/groovy/org/gradle/fileevents/internal/BasicFileEventFunctionsTest.groovy
+++ b/src/test/groovy/org/gradle/fileevents/internal/BasicFileEventFunctionsTest.groovy
@@ -28,7 +28,6 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
-import static java.util.concurrent.TimeUnit.SECONDS
 import static org.gradle.fileevents.FileWatchEvent.ChangeType.CREATED
 import static org.gradle.fileevents.FileWatchEvent.ChangeType.MODIFIED
 import static org.gradle.fileevents.FileWatchEvent.ChangeType.REMOVED
@@ -747,15 +746,6 @@ class BasicFileEventFunctionsTest extends AbstractFileEventFunctionsTest {
         expectLogMessage(INFO, "Event queue overflow, dropping all events")
         expectLogMessage(ERROR, "Couldn't queue event: OVERFLOW (EVENT_QUEUE) at null")
         expectLogMessage(ERROR, "Couldn't queue event: TERMINATE")
-    }
-
-    def "can handle watcher start timing out"() {
-        when:
-        service.newWatcher(eventQueue).start(0, SECONDS)
-
-        then:
-        def ex = thrown AbstractFileEventFunctions.FileWatcherTimeoutException
-        ex.message == "Starting the watcher timed out"
     }
 
     @IgnoreIf(value = { Platform.current().windows }, reason = "Windows 2019 Server does not handle this")

--- a/src/test/groovy/org/gradle/fileevents/internal/SyntheticFileEventFunctionsTest.groovy
+++ b/src/test/groovy/org/gradle/fileevents/internal/SyntheticFileEventFunctionsTest.groovy
@@ -4,28 +4,51 @@ import org.gradle.fileevents.testfixtures.TestFileEventFunctions
 import spock.lang.Specification
 
 import java.util.concurrent.LinkedBlockingDeque
-import java.util.concurrent.TimeUnit
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static java.util.concurrent.TimeUnit.SECONDS
 
 class SyntheticFileEventFunctionsTest extends Specification {
-    def service = new TestFileEventFunctions()
     def eventQueue = new LinkedBlockingDeque()
-    def watcher = service
-        .newWatcher(eventQueue)
-        .start()
 
     def "normal termination produces termination event"() {
+        def service = new TestFileEventFunctions()
+        def watcher = service
+            .newWatcher(eventQueue)
+            .start()
+
         when:
         watcher.shutdown()
-        watcher.awaitTermination(1, TimeUnit.SECONDS)
+        watcher.awaitTermination(1, SECONDS)
+
         then:
         eventQueue*.toString() == ["TERMINATE"]
     }
 
     def "failure in run loop produces failure event followed by termination events"() {
+        def service = new TestFileEventFunctions()
+        def watcher = service
+            .newWatcher(eventQueue)
+            .start()
+
         when:
         watcher.injectFailureIntoRunLoop()
-        watcher.awaitTermination(1, TimeUnit.SECONDS)
+        watcher.awaitTermination(1, SECONDS)
+
         then:
         eventQueue*.toString() == ["FAILURE Error", "TERMINATE"]
+    }
+
+    def "can handle watcher start timing out"() {
+        def service = new TestFileEventFunctions({
+            Thread.sleep(200)
+        })
+
+        when:
+        service.newWatcher(eventQueue).start(100, MILLISECONDS)
+
+        then:
+        def ex = thrown AbstractFileEventFunctions.FileWatcherTimeoutException
+        ex.message == "Starting the watcher timed out"
     }
 }

--- a/src/test/groovy/org/gradle/fileevents/testfixtures/TestFileEventFunctions.groovy
+++ b/src/test/groovy/org/gradle/fileevents/testfixtures/TestFileEventFunctions.groovy
@@ -23,12 +23,18 @@ import java.util.concurrent.LinkedBlockingQueue
 
 class TestFileEventFunctions extends AbstractFileEventFunctions<TestFileWatcher> {
 
+    private final Closure initRunLoop
+
+    TestFileEventFunctions(Closure initRunLoop = {}) {
+        this.initRunLoop = initRunLoop
+    }
+
     @Override
     WatcherBuilder newWatcher(BlockingQueue<FileWatchEvent> eventQueue) {
         new WatcherBuilder(eventQueue)
     }
 
-    static class TestFileWatcher extends AbstractFileEventFunctions.AbstractFileWatcher {
+    class TestFileWatcher extends AbstractFileEventFunctions.AbstractFileWatcher {
         enum Command {
             FAIL, TERMINATE
         }
@@ -41,6 +47,7 @@ class TestFileEventFunctions extends AbstractFileEventFunctions<TestFileWatcher>
 
         @Override
         protected void initializeRunLoop() {
+            initRunLoop.call()
         }
 
         @Override
@@ -66,7 +73,7 @@ class TestFileEventFunctions extends AbstractFileEventFunctions<TestFileWatcher>
 
         @Override
         protected boolean awaitTermination(long timeoutInMillis) {
-            return true;
+            return true
         }
 
         @Override
@@ -80,7 +87,7 @@ class TestFileEventFunctions extends AbstractFileEventFunctions<TestFileWatcher>
         }
     }
 
-    static class WatcherBuilder extends AbstractFileEventFunctions.AbstractWatcherBuilder<TestFileWatcher> {
+    class WatcherBuilder extends AbstractFileEventFunctions.AbstractWatcherBuilder<TestFileWatcher> {
         WatcherBuilder(BlockingQueue<FileWatchEvent> eventQueue) {
             super(eventQueue)
         }


### PR DESCRIPTION
This makes the test fully reproducible.