### PR TITLE
Require explicit call to FileEvents.init()

### DIFF
--- a/src/test/groovy/org/gradle/fileevents/internal/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/org/gradle/fileevents/internal/AbstractFileEventFunctionsTest.groovy
@@ -84,6 +84,8 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         assert rootDir.mkdirs()
         uncaughtFailureOnThread = []
         expectedLogMessages = [:]
+
+        FileEvents.init(null)
     }
 
     def cleanup() {


### PR DESCRIPTION
Previously it was possible to call `FileEvents.get()` without previously calling `FileEvents.init()`, but this is now forbidden, and an explicit call must be made.

We also make sure to ignore any subsequent calls to `FileEvents.init()`.