### PR TITLE
Do not initialize library implicitly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ group = "org.gradle.fileevents"
 
 dependencies {
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
-    api("net.rubygrapefruit:native-platform:0.22-milestone-26")
+    api("net.rubygrapefruit:native-platform:0.22-milestone-28")
     implementation("org.slf4j:slf4j-api:1.7.36")
     testImplementation(platform("org.junit:junit-bom:5.11.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/src/test/groovy/org/gradle/fileevents/internal/AbstractFileEventFunctionsTest.groovy
+++ b/src/test/groovy/org/gradle/fileevents/internal/AbstractFileEventFunctionsTest.groovy
@@ -33,6 +33,8 @@ import spock.lang.Specification
 import spock.lang.TempDir
 import spock.lang.Timeout
 
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -50,6 +52,18 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
     public static final Logger LOGGER = LoggerFactory.getLogger(AbstractFileEventFunctionsTest)
 
     LoggingCapture logging = new LoggingCapture(NativeLogger, Level.INFO)
+
+    private static FileEvents fileEventsIntegration
+
+    protected static FileEvents getFileEvents() {
+        if (fileEventsIntegration == null) {
+            def testOutputDir = Paths.get("build/test-outputs")
+            Files.createDirectories(testOutputDir)
+            def tempDir = Files.createTempDirectory(testOutputDir, "file-events")
+            fileEventsIntegration = FileEvents.init(tempDir.toFile())
+        }
+        return fileEventsIntegration
+    }
 
     @TempDir
     File tmpDir
@@ -84,8 +98,6 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
         assert rootDir.mkdirs()
         uncaughtFailureOnThread = []
         expectedLogMessages = [:]
-
-        FileEvents.init(null)
     }
 
     def cleanup() {
@@ -152,7 +164,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             @Memoized
             @Override
             OsxFileEventFunctions getService() {
-                FileEvents.get(OsxFileEventFunctions)
+                AbstractFileEventFunctionsTest.getFileEvents().get(OsxFileEventFunctions)
             }
 
             @Override
@@ -173,7 +185,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             @Memoized
             @Override
             LinuxFileEventFunctions getService() {
-                FileEvents.get(LinuxFileEventFunctions)
+                AbstractFileEventFunctionsTest.getFileEvents().get(LinuxFileEventFunctions)
             }
 
             @Override
@@ -193,7 +205,7 @@ abstract class AbstractFileEventFunctionsTest extends Specification {
             @Memoized
             @Override
             WindowsFileEventFunctions getService() {
-                FileEvents.get(WindowsFileEventFunctions)
+                AbstractFileEventFunctionsTest.getFileEvents().get(WindowsFileEventFunctions)
             }
 
             @Override


### PR DESCRIPTION
Previously we allowed the library to be initialized in the system temp directory if `null` was passed for the cache directory.
This is a security vulnerability and thus is not allowed anymore. An extraction directory has to be specified explicitly from now on.

See also:
- https://github.com/gradle/native-platform/pull/353