### PR TITLE
Ubuntu 20.04 is deprecated

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-latest
           - macos-13
           - macos-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,14 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-latest, macos-13, macos-latest, windows-2019, windows-latest, alpine ]
+        os:
+          - ubuntu-20.04
+          - ubuntu-latest
+          - macos-13
+          - macos-latest
+          - windows-2019
+          - windows-latest
+          - alpine
         include:
             - os: alpine
               container: eclipse-temurin:17-alpine


### PR DESCRIPTION
> The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01

See also:
* https://github.com/actions/runner-images/issues/11101

We thus move GitHub Actions lowest version to 22.04